### PR TITLE
When compiling with gcc, use gcc as preprocessor

### DIFF
--- a/src/semiwrap/makeplan.py
+++ b/src/semiwrap/makeplan.py
@@ -42,6 +42,20 @@ class CppMacroValue:
 
 
 @dataclasses.dataclass(frozen=True)
+class CompilerInfo:
+    """
+    Represents N arguments to be injected:
+
+    - argument_syntax: gcc, msvc, or other
+    - c++ standard
+    - actual arguments to run the compiler
+
+    """
+
+    pass
+
+
+@dataclasses.dataclass(frozen=True)
 class LocalDependency:
     name: str
     include_paths: T.Tuple[pathlib.Path, ...]
@@ -87,6 +101,7 @@ class BuildTarget:
             BuildTarget,
             BuildTargetOutput,
             CppMacroValue,
+            CompilerInfo,
         ],
         ...,
     ]
@@ -539,6 +554,7 @@ class _BuildPlanner:
             header2dat_args.append(all_type_casters)
             header2dat_args.append(OutputFile(f"{yml}.dat"))
             header2dat_args.append(Depfile(f"{yml}.d"))
+            header2dat_args.append(CompilerInfo())
 
             datfile = BuildTarget(
                 command="header2dat", args=tuple(header2dat_args), install_path=None

--- a/src/semiwrap/tool/create_yaml.py
+++ b/src/semiwrap/tool/create_yaml.py
@@ -4,7 +4,7 @@ import typing as T
 
 from ..autowrap.generator_data import MissingReporter
 from ..cmd.header2dat import make_argparser, generate_wrapper
-from ..makeplan import InputFile, makeplan, BuildTarget
+from ..makeplan import InputFile, makeplan, BuildTarget, CompilerInfo
 
 
 class GenCreator:
@@ -63,6 +63,8 @@ class GenCreator:
                     argv.append(str(arg.path.absolute()))
                 elif isinstance(arg, pathlib.Path):
                     argv.append(str(arg.absolute()))
+                elif isinstance(arg, CompilerInfo):
+                    argv += ["pcpp", "ignored", "ignored"]
                 else:
                     # anything else shouldn't matter
                     argv.append("ignored")
@@ -80,8 +82,10 @@ class GenCreator:
                 dst_dat=None,
                 dst_depfile=None,
                 include_paths=sargs.include_paths,
+                compiler_flavor="pcpp",
+                compiler_args=[],
                 casters={},
-                pp_defines=sargs.pp_defines,
+                pp_defines=[],
                 missing_reporter=reporter,
                 report_only=True,
             )


### PR DESCRIPTION
- MSVC doesn't have an easy to implement depfile support
- This solves some issues with cross compilation