### PR TITLE
ci: Update for GitHub Actions changes

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -39,14 +39,14 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - uses: pre-commit/action@v3.0.1
   
   check-doc:
     runs-on: ubuntu-22.04
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
       with:
         submodules: true
 
@@ -62,7 +62,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
         fetch-depth: 0
@@ -89,7 +89,7 @@ jobs:
     strategy:
       max-parallel: ${{ fromJSON(needs.setup_concurrency.outputs.max-parallel).v }}
       matrix:
-        os: ["ubuntu-22.04", "macos-13", "windows-2022"]
+        os: ["ubuntu-22.04", "macos-14", "windows-2022"]
         python_version:
         - '3.8'
         - '3.9'
@@ -97,29 +97,23 @@ jobs:
         - '3.11'
         - '3.12'
         - '3.13'
-        architecture: [x64]
-        # exclude:
-        # - os: macos-13
-        #   architecture: x86
-        # - os: ubuntu-22.04
-        #   architecture: x86
-        include:
+        exclude:
         - os: macos-14
-          python_version: 3.9
-          architecture: arm64
+          python_version: '3.8'
+        include:
+        - os: macos-13
+          python_version: '3.8'
         - os: ubuntu-22.04-arm
-          python_version: 3.11
-          architecture: arm64
+          python_version: '3.11'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
       with:
         submodules: true
 
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python_version }}
-        architecture: ${{ matrix.architecture }}
     
     - name: Download build artifacts
       uses: actions/download-artifact@v4
@@ -130,7 +124,7 @@ jobs:
     - name: Setup ccache
       uses: robotpy/ccache-action@fork
       with:
-          key: ${{ matrix.os }}-${{ matrix.architecture }}-${{ matrix.python_version }}
+          key: ${{ matrix.os }}-${{ matrix.python_version }}
           variant: ccache
 
     - name: Setup MSVC
@@ -174,7 +168,7 @@ jobs:
       image: "${{ matrix.container }}"
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
       with:
         submodules: true
 


### PR DESCRIPTION
- macos-13 is deprecated and will be removed next month: https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/
- Specifying the `architecture` to `actions/setup-python` is unnecessary for the default host architecture