### PR TITLE
Fix bazel update-yaml, non bazel update-init

### DIFF
--- a/src/semiwrap/tool/create_imports.py
+++ b/src/semiwrap/tool/create_imports.py
@@ -155,4 +155,4 @@ class UpdateInit:
                 base = to_update
                 compiled = None
 
-            ic.create(base, compiled, True)
+            ic.create(base, compiled, True, None)

--- a/src/semiwrap/tool/update_yaml.py
+++ b/src/semiwrap/tool/update_yaml.py
@@ -246,7 +246,7 @@ class YamlUpdater:
                 output_file = override_output_directory / pathlib.Path(
                     *disabled_file.parts[1:]
                 )
-            shutil.copy(project_root / disabled_file, output_file)
+                shutil.copy(project_root / disabled_file, output_file)
 
         # Delete files that are no longer used in generation
         deleted_files = original_files.difference(generated_files).difference(


### PR DESCRIPTION
I must have messed up making the patch for #292. This fixes the enable if thing and should only affect when `update-yaml` is run with `--override_output_directory`.

Also I happened to notice that I broke `update-init` when adding a directory there. I only test `create-init` not the one that runs on multiple packages for a project

Sorry for requiring another release to build with `allwpilib` 🤦 