### PR TITLE
Switch to using pybind11 pypi package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/semiwrap/pybind11"]
-	path = src/semiwrap/pybind11
-	url = https://github.com/pybind/pybind11.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "typing-extensions",
     "pyyaml >= 5.1",
     "pybind11-stubgen ~= 2.5.1",
+    "pybind11 ~= 3.0.1",
 ]
 
 [project.entry-points.hatch]
@@ -56,15 +57,6 @@ version-file = "src/semiwrap/version.py"
 
 [tool.hatch.build.targets.sdist]
 packages = ["src/semiwrap"]
-exclude = [
-    "/src/semiwrap/pybind11"
-]
-[tool.hatch.build.targets.sdist.force-include]
-"./src/semiwrap/pybind11/include" = "./semiwrap/pybind11/include"
-"./src/semiwrap/pybind11/LICENSE" = "./LICENSE-pybind11.txt"
 
 [tool.black]
 target-version = ["py38"]
-extend-exclude = '''
-^/src/semiwrap/pybind11
-'''

--- a/src/semiwrap/cmd/make_pyi.py
+++ b/src/semiwrap/cmd/make_pyi.py
@@ -59,6 +59,14 @@ def _write_pyi(
         for infile in generated_pyi.keys():
             (tmpdir_pth / infile).parent.mkdir(parents=True, exist_ok=True)
 
+        # Fix typing.Annotated bug in < 3.8
+        # - the Right Fix would be to emit typing_extensions.Annotated in pybind11,
+        #   but Python 3.8 support will go away soon so not worth it
+        if sys.version_info < (3, 9):
+            import typing_extensions
+
+            T.Annotated = typing_extensions.Annotated
+
         pybind11_stubgen.main()
 
         # stubgen doesn't take a direct output filename, so move the file

--- a/src/semiwrap/semiwrap-pybind11.pc
+++ b/src/semiwrap/semiwrap-pybind11.pc
@@ -1,8 +1,0 @@
-prefix=${pcfiledir}
-includedir=${prefix}/pybind11/include
-
-Name: semiwrap-pybind11
-Description: Semiwrap specific version of pybind11
-Version: 3.0.0.dev1
-Cflags: -I${includedir}
-Libs:

--- a/src/semiwrap/semiwrap.pc
+++ b/src/semiwrap/semiwrap.pc
@@ -4,6 +4,6 @@ includedir=${prefix}/include
 Name: semiwrap
 Description: Semiwrap compile flags and include directories
 Version: 2025
-Requires: semiwrap-pybind11
+Requires: pybind11
 Cflags: -I${includedir}
 Libs:


### PR DESCRIPTION
- This would break compatibility with prior semiwrap versions because of pybind11 ABI updates