### PR TITLE
Have `create-imports` use `sys.executable` while running black

### DIFF
--- a/src/semiwrap/tool/create_imports.py
+++ b/src/semiwrap/tool/create_imports.py
@@ -86,7 +86,7 @@ class ImportCreator:
         )
 
         content = subprocess.check_output(
-            ["black", "-", "-q"], input=stmt.encode("utf-8")
+            [sys.executable, "-m", "black", "-", "-q"], input=stmt.encode("utf-8")
         ).decode("utf-8")
 
         if write:


### PR DESCRIPTION
I don't know the background semantics behind this, but in order for bazel to find the hermetic version of the black dependency you must invoke it with `sys.executable`. Locally on my computer is was finding the non-hermetic version but was starting to fail as I tried to run it on CI.

All other `subprocess` calls already use `sys.executable -m`.